### PR TITLE
chore: add docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,5 @@ RUN bundle install --without development test
 
 COPY . /app/
 
-CMD ["bin/rails", "s", "-b", "0.0.0.0"]
+ENTRYPOINT ./docker-entrypoint.sh
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+bundle install --without development test
+bin/rails db:migrate
+bin/rails server -b 0.0.0.0


### PR DESCRIPTION
In a docker-compose file. The current oop-core-transmissions block will have to change `command` to `entrypoint` or the transmissions will not run and you will get duplicate core services.